### PR TITLE
Removed unnecessary Air block check

### DIFF
--- a/NoSideTorch.java
+++ b/NoSideTorch.java
@@ -35,7 +35,7 @@ public final class NoSideTorch extends JavaPlugin implements Listener {
             Location loc = block.getLocation();
             Location belowLoc = new Location(loc.getWorld(), loc.getX(), loc.getY()-1, loc.getZ());
             Block belowBlock = belowLoc.getBlock();
-            if(belowBlock.getType() != Material.AIR && belowBlock.getType().isSolid())
+            if(belowBlock.getType().isSolid())
             {
                 player.sendMessage("'" + name + "' Thou Shall Not Side Torch!");
                 event.setCancelled(true);


### PR DESCRIPTION
Air is not classified as a solid block according to: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html#isSolid--